### PR TITLE
add --server-name and --scheme option for smoking URL

### DIFF
--- a/bin/wallflower
+++ b/bin/wallflower
@@ -46,6 +46,10 @@ as long as the shorter version is unambiguous.
                             localhost ones), can include * as a wildcard,
                             like *.example.com
 
+ --server-name              Server name you deploy (Optional)
+
+ --scheme                   URL scheme you use in production (Optional)
+
  --quiet                    Don't display URLs as they're processed
 
 

--- a/lib/App/Wallflower.pm
+++ b/lib/App/Wallflower.pm
@@ -32,6 +32,8 @@ sub new_with_options {
         'follow!',       'filter|files|F',
         'quiet',         'include|INC=s@',
         'host=s@',
+        'server-name=s',
+        'scheme=s',
         'help',          'manual',
         'tutorial',
     ) or pod2usage(
@@ -77,6 +79,8 @@ sub new_with_options {
             application => Plack::Util::load_psgi( $option{application} ),
             ( destination => $option{destination} )x!! $option{destination},
             ( index       => $option{index}       )x!! $option{index},
+            ( server_name => $option{server-name} )x!! $option{server-name},
+            ( scheme      => $option{scheme}      )x!! $option{scheme},
         ),
     }, $class;
 

--- a/lib/Wallflower.pm
+++ b/lib/Wallflower.pm
@@ -10,7 +10,7 @@ use HTTP::Date qw( time2str );
 use Carp;
 
 # quick getters
-for my $attr (qw( application destination env index )) {
+for my $attr (qw( application destination env index server_name scheme )) {
     no strict 'refs';
     *$attr = sub { $_[0]{$attr} };
 }
@@ -68,6 +68,7 @@ sub get {
 
         # current instance defaults
         %{ $self->env },
+        ('psgi.url_scheme' => $self->scheme )x!! $self->scheme,
 
         # request-related environment variables
         REQUEST_METHOD => 'GET',
@@ -77,8 +78,8 @@ sub get {
         PATH_INFO       => $uri->path,
         REQUEST_URI     => $uri->path,
         QUERY_STRING    => '',
-        SERVER_NAME     => 'localhost',
-        SERVER_PORT     => '80',
+        SERVER_NAME     => $self->server_name || 'localhost',
+        SERVER_PORT     => ($self->scheme || '') eq 'https' ? 443 : 80,
         SERVER_PROTOCOL => "HTTP/1.0",
 
         # wallflower defaults
@@ -90,7 +91,7 @@ sub get {
     $env->{HTTP_IF_MODIFIED_SINCE} = time2str( ( stat _ )[9] ) if -e $target;
 
     # fixup URI (needed to resolve relative URLs in retrieved documents)
-    $uri->scheme('http') if !$uri->scheme;
+    $uri->scheme($self->scheme || 'http') if !$uri->scheme;
     $uri->host( $env->{SERVER_NAME} ) if !$uri->host;
 
     # get the content

--- a/lib/Wallflower.pm
+++ b/lib/Wallflower.pm
@@ -193,6 +193,14 @@ Additional environment key/value pairs.
 The default filename for URLs ending in C</>.
 The default value is F<index.html>.
 
+=item C<server_name>
+
+Server name you deploy (Optional)
+
+=item C<scheme>
+
+URL scheme you use in production (Optional)
+
 =back
 
 =method get( $url )

--- a/t/50-smoke.t
+++ b/t/50-smoke.t
@@ -1,0 +1,75 @@
+use strict;
+use warnings;
+use Test::More;
+use File::Temp qw( tempdir );
+use List::Util qw( sum );
+use Wallflower;
+
+# setup test data
+my @tests;
+
+# test data is an array ref containing:
+# - quick description of the app
+# - destination directory
+# - the app itself
+# - a list of test url for the app
+#   as [ url, status, headers, file, content ]
+
+push @tests, [
+    'direct content',
+    tempdir( CLEANUP => 1 ),
+    sub {
+        my $env = shift;
+        require Plack::Request;
+        my $req = Plack::Request->new($env);
+        my $uri = $req->uri;
+
+        [   200,
+            [ 'Content-Type' => 'text/plain', 'Content-Length' => length($uri) ],
+            [ $uri ]
+        ];
+    },
+    [   '/' => 200,
+        [ 'Content-Type' => 'text/plain', 'Content-Length' => 24 ],
+        'index.html',
+        'http://blah.example.com/'
+    ],
+    [   '/clunk' => 200,
+        [ 'Content-Type' => 'text/plain', 'Content-Length' => 29 ],
+        'clunk', 'http://blah.example.com/clunk'
+    ],
+];
+
+plan tests => sum map 2 * ( @$_ - 3 ), @tests;
+
+for my $t (@tests) {
+    my ( $desc, $dir, $app, @urls ) = @$t;
+
+    my $wf = Wallflower->new(
+        application => $app,
+        destination => $dir,
+        server_name => 'blah.example.com',
+    );
+
+    for my $u (@urls) {
+        my ( $url, $status, $headers, $file, $content ) = @$u;
+
+        my $result = $wf->get($url);
+        is_deeply(
+            $result,
+            [   $status, $headers, $file && File::Spec->catfile( $dir, $file )
+            ],
+            "app ($desc) for $url"
+        );
+
+        if ( $status eq '200' ) {
+            my $file_content
+                = do { local $/; local @ARGV = ( $result->[2] ); <> };
+            is( $file_content, $content, "content ($desc) for $url" );
+        }
+        else {
+            is( $result->[2], '', "no file ($desc) for $url" );
+        }
+    }
+}
+

--- a/t/55-smoke-https.t
+++ b/t/55-smoke-https.t
@@ -1,0 +1,76 @@
+use strict;
+use warnings;
+use Test::More;
+use File::Temp qw( tempdir );
+use List::Util qw( sum );
+use Wallflower;
+
+# setup test data
+my @tests;
+
+# test data is an array ref containing:
+# - quick description of the app
+# - destination directory
+# - the app itself
+# - a list of test url for the app
+#   as [ url, status, headers, file, content ]
+
+push @tests, [
+    'direct content',
+    tempdir( CLEANUP => 1 ),
+    sub {
+        my $env = shift;
+        require Plack::Request;
+        my $req = Plack::Request->new($env);
+        my $uri = $req->uri;
+
+        [   200,
+            [ 'Content-Type' => 'text/plain', 'Content-Length' => length($uri) ],
+            [ $uri ]
+        ];
+    },
+    [   '/' => 200,
+        [ 'Content-Type' => 'text/plain', 'Content-Length' => 24 ],
+        'index.html',
+        'https://ssl.example.com/'
+    ],
+    [   '/clunk' => 200,
+        [ 'Content-Type' => 'text/plain', 'Content-Length' => 29 ],
+        'clunk', 'https://ssl.example.com/clunk'
+    ],
+];
+
+plan tests => sum map 2 * ( @$_ - 3 ), @tests;
+
+for my $t (@tests) {
+    my ( $desc, $dir, $app, @urls ) = @$t;
+
+    my $wf = Wallflower->new(
+        application => $app,
+        destination => $dir,
+        server_name => 'ssl.example.com',
+        scheme      => 'https',
+    );
+
+    for my $u (@urls) {
+        my ( $url, $status, $headers, $file, $content ) = @$u;
+
+        my $result = $wf->get($url);
+        is_deeply(
+            $result,
+            [   $status, $headers, $file && File::Spec->catfile( $dir, $file )
+            ],
+            "app ($desc) for $url"
+        );
+
+        if ( $status eq '200' ) {
+            my $file_content
+                = do { local $/; local @ARGV = ( $result->[2] ); <> };
+            is( $file_content, $content, "content ($desc) for $url" );
+        }
+        else {
+            is( $result->[2], '', "no file ($desc) for $url" );
+        }
+    }
+}
+


### PR DESCRIPTION
Some application (e.g. Blog software) needs to output absolute URL for permalinks. The options support it.